### PR TITLE
Adds missing data in fetch response.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ function denock(options: DenockOptions): Interceptor {
 
   window.fetch = async (
     input: string | Request | URL,
-    init?: RequestInit | undefined,
+    init?: RequestInit | undefined
   ) => {
     callCounter++;
 
@@ -51,7 +51,7 @@ function denock(options: DenockOptions): Interceptor {
           if (request.body) {
             const readableStreamReader = request.body?.getReader();
             const extractedBody = await extractBodyFromRequest(
-              readableStreamReader,
+              readableStreamReader
             );
             originalBody = extractedBody ? extractedBody : originalBody;
           }
@@ -83,6 +83,10 @@ function denock(options: DenockOptions): Interceptor {
     return {
       status: replyStatus || 200,
       json: () => responseBody as any,
+      text: () => responseBody as any,
+      arrayBuffer: () => responseBody as any,
+      blob: () => responseBody as any,
+      formData: () => responseBody as any,
     } as Response;
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,7 @@ function denock(options: DenockOptions): Interceptor {
     }
 
     return {
+      ok: replyStatus === undefined || replyStatus < 400 ? true : false,
       status: replyStatus || 200,
       json: () => responseBody as any,
       text: () => responseBody as any,


### PR DESCRIPTION
Closes #4 
Closes #5 

This PR adds all missing methods for doing a fetch call as shown here: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch

This aligns with Deno, since Deno uses the same API as the browser, and no Node fetch.

All added methods just return the normal body, since the responseBody is assumed to be in final output form. 

This also adds `response.ok` which is a boolean set to true when the response is < 400 or the default of 200. 