### PR TITLE
Add optional responseHeaders to allow testing against response headers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ function denock(options: DenockOptions): Interceptor {
   let callCounter = 0;
   let callLimit = 1;
 
-  const { responseBody, interception, replyStatus } = options;
+  const { responseBody, responseHeaders, interception, replyStatus } = options;
 
   callLimit = interception || 1;
 
@@ -88,6 +88,7 @@ function denock(options: DenockOptions): Interceptor {
       arrayBuffer: () => responseBody as any,
       blob: () => responseBody as any,
       formData: () => responseBody as any,
+      headers: () => responseHeaders as any,
     } as Response;
   };
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -14,6 +14,8 @@ export interface DenockOptions {
   replyStatus?: number;
   /** This is the body that will be returned on interception*/
   responseBody: any;
+  /** This is the headers that will be returned on interception */
+  responseHeader?: Record<string, any>;
   /** Represent the number of call you wants to intercept*/
   interception?: number;
 }


### PR DESCRIPTION
I have a usage where I verify returned headers in a given function, and it would be very useful to be able to specify behavior when a returned header matches a given value.